### PR TITLE
Empty string array

### DIFF
--- a/detector/detect.go
+++ b/detector/detect.go
@@ -3,6 +3,7 @@ package detector
 import (
 	"bytes"
 	"io"
+	"io/ioutil"
 	"regexp"
 
 	"github.com/jfyne/csvd"
@@ -51,6 +52,11 @@ func (d *detector) DetectRowTerminator(reader io.Reader) string {
 
 // DetectDelimiter finds a slice of delimiter string.
 func (d *detector) DetectDelimiter(r io.Reader, enclosure byte) []string {
+	b, _ := ioutil.ReadAll(r)
+	if len(b) == 0 {
+		return []string{""}
+	}
+	r = bytes.NewReader(b)
 	csvReader := csvd.NewReader(r)
 	delimiter := csvReader.Comma
 	return []string{string(delimiter)}

--- a/detector/detect.go
+++ b/detector/detect.go
@@ -54,7 +54,7 @@ func (d *detector) DetectRowTerminator(reader io.Reader) string {
 func (d *detector) DetectDelimiter(r io.Reader, enclosure byte) []string {
 	b, _ := ioutil.ReadAll(r)
 	if len(b) == 0 {
-		return []string{""}
+		return []string{}
 	}
 	r = bytes.NewReader(b)
 	csvReader := csvd.NewReader(r)

--- a/detector/detect_test.go
+++ b/detector/detect_test.go
@@ -59,19 +59,23 @@ func TestDetectDelimiter1(t *testing.T) {
 	assert.NoError(t, err)
 	defer file2.Close()
 
+	unreachable := "blah"
 	testCases := []struct {
 		r         io.Reader
 		delimiter string
 	}{
 		{file1, ","},
 		{file2, ","},
-		{strings.NewReader(""), ""},
+		{strings.NewReader(""), unreachable},
 	}
 
 	for _, tc := range testCases {
 		delimiters := detector.DetectDelimiter(tc.r, '"')
 
 		fmt.Println(delimiters)
+		if len(delimiters) == 0 && tc.delimiter == unreachable {
+			return
+		}
 		assert.Equal(t, []string{tc.delimiter}, delimiters)
 	}
 }

--- a/detector/detect_test.go
+++ b/detector/detect_test.go
@@ -51,25 +51,29 @@ func TestIsPotentialDelimiter(t *testing.T) {
 func TestDetectDelimiter1(t *testing.T) {
 	detector := New()
 
-	file, err := os.OpenFile("./Fixtures/test1.csv", os.O_RDONLY, os.ModePerm)
+	file1, err := os.OpenFile("./Fixtures/test1.csv", os.O_RDONLY, os.ModePerm)
 	assert.NoError(t, err)
-	defer file.Close()
+	defer file1.Close()
 
-	delimiters := detector.DetectDelimiter(file, '"')
-	fmt.Println(delimiters)
-	assert.Equal(t, []string{","}, delimiters)
-}
-
-func TestDetectDelimiter2(t *testing.T) {
-	detector := New()
-
-	file, err := os.OpenFile("./Fixtures/test2.csv", os.O_RDONLY, os.ModePerm)
+	file2, err := os.OpenFile("./Fixtures/test2.csv", os.O_RDONLY, os.ModePerm)
 	assert.NoError(t, err)
-	defer file.Close()
+	defer file2.Close()
 
-	delimiters := detector.DetectDelimiter(file, '"')
-	fmt.Println(delimiters)
-	assert.Equal(t, []string{","}, delimiters)
+	testCases := []struct {
+		r         io.Reader
+		delimiter string
+	}{
+		{file1, ","},
+		{file2, ","},
+		{strings.NewReader(""), ""},
+	}
+
+	for _, tc := range testCases {
+		delimiters := detector.DetectDelimiter(tc.r, '"')
+
+		fmt.Println(delimiters)
+		assert.Equal(t, []string{tc.delimiter}, delimiters)
+	}
 }
 
 func TestDetectRowTerminator(t *testing.T) {
@@ -85,6 +89,8 @@ func TestDetectRowTerminator(t *testing.T) {
 	wooString := "woo\rhere\rbe no pippy!\r"
 	wooR := strings.NewReader(wooString)
 
+	emptyR := strings.NewReader("")
+
 	testCases := []struct {
 		r          io.Reader
 		terminator string
@@ -93,6 +99,7 @@ func TestDetectRowTerminator(t *testing.T) {
 		{wooR, "\r"},
 		{booR, "\r\n"},
 		{badRead{}, ""},
+		{emptyR, ""},
 	}
 
 	for _, tc := range testCases {


### PR DESCRIPTION
Empty readers should return empty string arrays, not arrays of empty strings. 